### PR TITLE
Disable HTTP cache by default in controller

### DIFF
--- a/bundle/Controller/InformationCollectionController.php
+++ b/bundle/Controller/InformationCollectionController.php
@@ -3,6 +3,7 @@
 namespace Netgen\Bundle\InformationCollectionBundle\Controller;
 
 use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
+use eZ\Publish\Core\MVC\Symfony\View\CachableView;
 use Netgen\Bundle\InformationCollectionBundle\InformationCollectionTrait;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
@@ -26,6 +27,11 @@ class InformationCollectionController implements ContainerAwareInterface
         $parameters = $this->collectInformation($view, $request);
 
         $view->addParameters($parameters);
+
+        if ($view instanceof CachableView) {
+            $view->setCacheEnabled(false);
+        }
+        
         return $view;
     }
 }

--- a/bundle/Controller/InformationCollectionLegacyController.php
+++ b/bundle/Controller/InformationCollectionLegacyController.php
@@ -29,7 +29,7 @@ class InformationCollectionLegacyController implements ContainerAwareInterface
 
         $params += $parameters;
 
-        return $this->container
+        $response = $this->container
             ->get('ez_content')
             ->viewLocation(
                 $locationId,
@@ -37,5 +37,9 @@ class InformationCollectionLegacyController implements ContainerAwareInterface
                 $layout,
                 $params
             );
+
+        $response->setPrivate();
+
+        return $response;
     }
 }

--- a/bundle/Resources/config/parameters.yml
+++ b/bundle/Resources/config/parameters.yml
@@ -1,2 +1,2 @@
 parameters:
-    netgen.default.information_collection.form.use_csrf: false
+    netgen.default.information_collection.form.use_csrf: true


### PR DESCRIPTION
Symfony forms have a CSRF token which is cached due to eZ full view caching config.

This disables the cache by default, since most of the time you don't want to cache the feedback form page.