### PR TITLE
Fix resolving of email templates per content type

### DIFF
--- a/bundle/Action/ActionRegistry.php
+++ b/bundle/Action/ActionRegistry.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\Bundle\InformationCollectionBundle\Action;
 
+use Netgen\Bundle\InformationCollectionBundle\DependencyInjection\ConfigurationConstants;
 use Netgen\Bundle\InformationCollectionBundle\Event\InformationCollected;
 use Netgen\Bundle\InformationCollectionBundle\Exception\ActionFailedException;
 use Netgen\Bundle\InformationCollectionBundle\Priority;
@@ -116,8 +117,8 @@ class ActionRegistry
      */
     protected function prepareConfig($contentTypeIdentifier)
     {
-        if (!empty($this->config['content_types'][$contentTypeIdentifier])) {
-            return $this->config['content_types'][$contentTypeIdentifier];
+        if (!empty($this->config[ConfigurationConstants::CONTENT_TYPES][$contentTypeIdentifier])) {
+            return $this->config[ConfigurationConstants::CONTENT_TYPES][$contentTypeIdentifier];
         }
 
         if (!empty($this->config['default'])) {

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -33,7 +33,7 @@ class Configuration extends SiteAccessConfiguration
                             ->end()
                         ->end()
 
-                        ->arrayNode('content_types')
+                        ->arrayNode(ConfigurationConstants::CONTENT_TYPES)
                             ->prototype('array')
                                 ->prototype('scalar')
                                     ->isRequired()
@@ -57,7 +57,7 @@ class Configuration extends SiteAccessConfiguration
                                             ->isRequired()
                                             ->cannotBeEmpty()
                                         ->end()
-                                        ->arrayNode('content_types')
+                                        ->arrayNode(ConfigurationConstants::CONTENT_TYPES)
                                             ->prototype('scalar')
                                                 ->isRequired()
                                                 ->cannotBeEmpty()

--- a/bundle/DependencyInjection/ConfigurationConstants.php
+++ b/bundle/DependencyInjection/ConfigurationConstants.php
@@ -15,4 +15,6 @@ class ConfigurationConstants
     const SETTINGS_ROOT = 'netgen_information_collection';
 
     const SETTINGS_DEFAULT = 'default';
+
+    const CONTENT_TYPES = 'content_types';
 }

--- a/bundle/Factory/EmailDataFactory.php
+++ b/bundle/Factory/EmailDataFactory.php
@@ -136,8 +136,8 @@ class EmailDataFactory
      */
     protected function resolveTemplate($contentTypeIdentifier)
     {
-        if (array_key_exists($contentTypeIdentifier, $this->config[ConfigurationConstants::TEMPLATES])) {
-            return $this->config[ConfigurationConstants::TEMPLATES][$contentTypeIdentifier];
+        if (array_key_exists($contentTypeIdentifier, $this->config[ConfigurationConstants::TEMPLATES][ConfigurationConstants::CONTENT_TYPES])) {
+            return $this->config[ConfigurationConstants::TEMPLATES][ConfigurationConstants::CONTENT_TYPES][$contentTypeIdentifier];
         }
 
         return $this->config[ConfigurationConstants::TEMPLATES][ConfigurationConstants::SETTINGS_DEFAULT];

--- a/tests/Factory/EmailDataFactoryTest.php
+++ b/tests/Factory/EmailDataFactoryTest.php
@@ -80,7 +80,9 @@ class EmailDataFactoryTest extends TestCase
         $this->config = array(
             'templates' => array(
                 'default' => 'AcmeBundle::email.html.twig',
-                'test_content_type' => 'AcmeBundle::test_content_type.html.twig',
+                'content_types' => array(
+                    'test_content_type' => 'AcmeBundle::test_content_type.html.twig',
+                )
             ),
             'default_variables' => array(
                 'sender' => 'sender@example.com',


### PR DESCRIPTION
The templates for email are not successfully resolved before this PR.

The main change is here https://github.com/netgen/NetgenInformationCollectionBundle/compare/master...iherak:fix-templates-resolving?expand=1#diff-86379760754936378f59b7d4004159b5R139, the rest was just adding constant so the same string is used throughout the repo.