### PR TITLE
Create named builder with content identifier and location id as name

### DIFF
--- a/bundle/Form/Builder/FormBuilder.php
+++ b/bundle/Form/Builder/FormBuilder.php
@@ -71,7 +71,8 @@ class FormBuilder
         $data = new DataWrapper(new InformationCollectionStruct(), $contentType, $location);
 
         $formBuilder = $this->formFactory
-            ->createBuilder(
+            ->createNamedBuilder(
+                $contentType->identifier . '_' . $location->id,
                 Kernel::VERSION_ID < 20800 ?
                     'ezforms_information_collection' :
                     InformationCollectionType::class,


### PR DESCRIPTION
This should fix the problem when you have multiple forms of the same type, or with different type but the same field name, on the same page. Currently, if there are two forms with the field `phone` on the same page, both fields will have `id="ezforms_information_collection_phone"` and their labels will have `for="ezforms_information_collection_phone"`. It will work only on first form, because the ID is no more unique.

After this fix, the form name will no longer be generated from form type (`ezforms_information_collection`). Instead it will be generated from content type identifier, with appended location ID (field example: `id="contact_form_123_phone"`).

WARNING: this will change form name attribute, as well as id and name attributes on each field.