### PR TITLE
introduce 'infocollector => read' policy

### DIFF
--- a/bundle/NetgenInformationCollectionBundle.php
+++ b/bundle/NetgenInformationCollectionBundle.php
@@ -5,6 +5,7 @@ namespace Netgen\Bundle\InformationCollectionBundle;
 use Netgen\Bundle\InformationCollectionBundle\DependencyInjection\Compiler\ActionsPass;
 use Netgen\Bundle\InformationCollectionBundle\DependencyInjection\Compiler\CustomFieldHandlersPass;
 use Netgen\Bundle\InformationCollectionBundle\DependencyInjection\Compiler\FieldAnonymizerVisitorPass;
+use Netgen\Bundle\InformationCollectionBundle\PolicyProvider\InformationCollectionPolicyProvider;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -20,5 +21,8 @@ class NetgenInformationCollectionBundle extends Bundle
         $container->addCompilerPass(new ActionsPass());
         $container->addCompilerPass(new CustomFieldHandlersPass());
         $container->addCompilerPass(new FieldAnonymizerVisitorPass());
+
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addPolicyProvider(new InformationCollectionPolicyProvider());
     }
 }

--- a/bundle/PolicyProvider/InformationCollectionPolicyProvider.php
+++ b/bundle/PolicyProvider/InformationCollectionPolicyProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\InformationCollectionBundle\PolicyProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;
+
+class InformationCollectionPolicyProvider implements PolicyProviderInterface
+{
+    /**
+     * @param ConfigBuilderInterface $configBuilder
+     *
+     * @return $this
+     */
+    public function addPolicies(ConfigBuilderInterface $configBuilder)
+    {
+        $configBuilder->addConfig([
+            'infocollector' => [
+                'read' => [],
+            ],
+        ]);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
This is a preparation to be able to check permissions in new ezplatform symfony stack (needed by https://github.com/netgen/NetgenEnhancedBinaryFileBundle/issues/9)