### PR TITLE
Do not use dynamic settings injection to avoid config resolver warning

### DIFF
--- a/bundle/Resources/config/factories.yml
+++ b/bundle/Resources/config/factories.yml
@@ -32,4 +32,4 @@ services:
         class: '%netgen_information_collection.factory.captcha.class%'
         arguments:
             - "@ezpublish.api.service.content_type"
-            - "$captcha;netgen_information_collection$"
+            - "@ezpublish.config.resolver"


### PR DESCRIPTION
Previous config causes the following warning on latest eZ Platform:

```
ConfigResolver was used by "@twig" before SiteAccess was initialized,
loading parameter(s) "$captcha$". As this can cause very hard to debug issues,
try to use ConfigResolver lazily, make the affected commands lazy,
make the service lazy or see if you can inject another lazy service.
```