### PR TITLE
fix return value getAttributeValue

### DIFF
--- a/lib/Core/Service/ExporterService.php
+++ b/lib/Core/Service/ExporterService.php
@@ -97,9 +97,7 @@ class ExporterService implements Exporter
 
                 $res = preg_replace(['/\r|\n/'], [' '], $value);
 
-                if ($res === null) {
-                    return '';
-                }
+                return $res ?? '';
             }
         }
 


### PR DESCRIPTION
The method `Netgen\InformationCollection\Core\Service\ExporterService::getAttributeValue()` return alway empty string.