### PR TITLE
Allow non admin user in backoffice

### DIFF
--- a/lib/Integration/EzPlatformAdmin/MenuListener.php
+++ b/lib/Integration/EzPlatformAdmin/MenuListener.php
@@ -20,7 +20,11 @@ class MenuListener implements EventSubscriberInterface
     public function onMenuConfigure(ConfigureMenuEvent $event)
     {
         $menu = $event->getMenu();
-
+        
+        if (!isset($menu[MainMenuBuilder::ITEM_ADMIN])) {
+            return;
+        }
+        
         $menu[MainMenuBuilder::ITEM_ADMIN]->addChild(
             'information_collection',
             [


### PR DESCRIPTION
This PR fixes the error `Call to a member function addChild() on null` when a user without admin right is connected to the eZ Platform admin UI.

![image](https://user-images.githubusercontent.com/51637606/87556065-84a56200-c6b6-11ea-8206-e53c234fa7dc.png)
