### PR TITLE
Send Request as argument to form handler

### DIFF
--- a/lib/API/InformationCollectionTrait.php
+++ b/lib/API/InformationCollectionTrait.php
@@ -30,8 +30,8 @@ trait InformationCollectionTrait
         /** @var RequestStack $requestStack */
         $requestStack = $this->container->get('request_stack');
 
-        $form = $handler->getForm($view->getContent(), $view->getLocation());
         $request = $requestStack->getCurrentRequest();
+        $form = $handler->getForm($view->getContent(), $view->getLocation(), $request);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {


### PR DESCRIPTION
Request implemented as third parameter in InformationCollectionTrait resulted in Exception:

`Too few arguments to function Netgen\InformationCollection\Handler::getForm(), 2 passed in vendor/netgen/information-collection-bundle/lib/API/InformationCollectionTrait.php on line 33 and exactly 3 expected`

Bug introduced in https://github.com/netgen/NetgenInformationCollectionBundle/commit/d896af5a957e590358a89f9e807c7c5c2ac87d79