### PR TITLE
Set error_bubbling parameter to false

### DIFF
--- a/bundle/Ibexa/ContentForms/InformationCollectionType.php
+++ b/bundle/Ibexa/ContentForms/InformationCollectionType.php
@@ -45,6 +45,7 @@ class InformationCollectionType extends AbstractType implements DataMapperInterf
             $builder->add($fieldsDatum->fieldDefinition->identifier, InformationCollectionFieldType::class, [
                 'languageCode' => $options['languageCode'],
                 'mainLanguageCode' => $options['mainLanguageCode'],
+                'error_bubbling' => false,
             ]);
         }
 


### PR DESCRIPTION
Since new information collection form is compound form, error_bubling parameter is by default set to true and all of the validation errors are attached to the field parent. To prevent this and display form error by the problematic field, errror_bubbling needs to be set as false.

https://symfony.com/doc/5.x/reference/forms/types/form.html#error-bubbling