### PR TITLE
NGSTACK-492 smoke tests

### DIFF
--- a/bundle/DependencyInjection/NetgenInformationCollectionExtension.php
+++ b/bundle/DependencyInjection/NetgenInformationCollectionExtension.php
@@ -173,8 +173,8 @@ class NetgenInformationCollectionExtension extends Extension implements PrependE
             $xlsxExportFormatter->setAutowired(false);
             $xlsxExportFormatter->setAutoconfigured(false);
 
-            $definitions[] = $xlsExportFormatter;
-            $definitions[] = $xlsxExportFormatter;
+            $definitions[$xlsExportFormatter->getClass()] = $xlsExportFormatter;
+            $definitions[$xlsxExportFormatter->getClass()] = $xlsxExportFormatter;
         }
 
         if (!empty($definitions)) {


### PR DESCRIPTION
Weird issue - discovered while writing tests.
Seems that with the previous implementation these two services were registered without the id somehow. This seems to fix the problem.