### PR TITLE
Fix empty ezselection export of first selection

### DIFF
--- a/lib/API/Value/AttributeValue.php
+++ b/lib/API/Value/AttributeValue.php
@@ -21,7 +21,7 @@ class AttributeValue extends ValueObject
 
     public function __toString(): string
     {
-        if (!empty($this->dataText)) {
+        if ($this->dataText !== '') {
             return $this->dataText;
         }
 


### PR DESCRIPTION
The first element of a ezselection field is stored as "0" in the column data_text. Those values are missing in the export. This change fixes that.